### PR TITLE
Adapts to new message scheduler in 7.1.8

### DIFF
--- a/src/Content/MassTransit.Docker/MassTransit.Docker.csproj
+++ b/src/Content/MassTransit.Docker/MassTransit.Docker.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="MassTransit.AspNetCore" Version="[7.1.7,8.0)" />
-    <PackageReference Include="MassTransit.RabbitMQ" Version="[7.1.7,8.0)" />
+    <PackageReference Include="MassTransit.AspNetCore" Version="[7.1.8,8.0)" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="[7.1.8,8.0)" />
   </ItemGroup>
 </Project>

--- a/src/Content/MassTransit.Docker/Program.cs
+++ b/src/Content/MassTransit.Docker/Program.cs
@@ -27,7 +27,7 @@ namespace MassTransit.Docker
                 {
                     services.AddMassTransit(x =>
                     {
-                        x.AddRabbitMqMessageScheduler();
+                        x.AddDelayedMessageScheduler();
 
                         x.SetKebabCaseEndpointNameFormatter();
 
@@ -47,7 +47,7 @@ namespace MassTransit.Docker
                             if (IsRunningInContainer)
                                 cfg.Host("rabbitmq");
 
-                            cfg.UseRabbitMqMessageScheduler();
+                            cfg.UseDelayedMessageScheduler();
                             
                             cfg.ConfigureEndpoints(context);
                         });

--- a/src/Content/MassTransit.Worker/MassTransit.Worker.csproj
+++ b/src/Content/MassTransit.Worker/MassTransit.Worker.csproj
@@ -7,6 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="MassTransit.AspNetCore" Version="[7.1.7,8.0)" />
+    <PackageReference Include="MassTransit.AspNetCore" Version="[7.1.8,8.0)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Changes to get rid of obsolete warnings when it comes to configuring the scheduler.